### PR TITLE
Plots - reducing memory footprint

### DIFF
--- a/cli/cli_api_usage.py
+++ b/cli/cli_api_usage.py
@@ -1,5 +1,6 @@
-import click
 import datetime
+
+import click
 import plotly.express as px
 from flask import current_app as app
 from flask.cli import with_appcontext

--- a/cli/cli_api_usage.py
+++ b/cli/cli_api_usage.py
@@ -16,7 +16,7 @@ def api_usage():
 
 @api_usage.command()
 @click.option(
-    "--latest", default=30, type=int, help="Only shows data from latest days."
+    "--latest", default=-1, type=int, help="Only shows data from latest days."
 )
 @with_appcontext
 def plot_requests_hist(latest):
@@ -24,9 +24,15 @@ def plot_requests_hist(latest):
     click.echo("Reading database...")
 
     table = md.ApiUsage
-    sql_query = table.query.filter(
-        table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
-    ).with_entities(table.datetime, table.status)
+
+    sql_query = table.query
+
+    if latest >= 0:
+        sql_query = sql_query.filter(
+            table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
+        )
+
+    sql_query = sql_query.with_entities(table.datetime, table.status)
     df = md.query_to_dataframe(sql_query)
 
     click.echo("Generating plot...")

--- a/cli/cli_usage.py
+++ b/cli/cli_usage.py
@@ -55,7 +55,7 @@ def stats():
 
 @usage.command()
 @click.option(
-    "--latest", default=30, type=int, help="Only shows data from latest days."
+    "--latest", default=-1, type=int, help="Only shows data from latest days."
 )
 @with_appcontext
 def plot_requests_per_blueprint_hist(latest):
@@ -63,9 +63,15 @@ def plot_requests_per_blueprint_hist(latest):
     click.echo("Reading database...")
 
     table = md.Usage
-    sql_query = table.query.filter(
-        table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
-    ).with_entities(table.datetime, table.blueprint)
+
+    sql_query = table.query
+
+    if latest >= 0:
+        sql_query = sql_query.filter(
+            table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
+        )
+
+    sql_query = sql_query.with_entities(table.datetime, table.blueprint)
     df = md.query_to_dataframe(sql_query)
 
     click.echo("Generating plot...")
@@ -98,16 +104,22 @@ def plot_requests_per_blueprint_hist(latest):
 
 @usage.command()
 @click.option(
-    "--latest", default=30, type=int, help="Only shows data from latest days."
+    "--latest", default=-1, type=int, help="Only shows data from latest days."
 )
 @with_appcontext
 def plot_views_per_blueprint_hist(latest):
 
     click.echo("Reading database...")
     table = md.Usage
-    sql_query = table.query.filter(
-        table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
-    ).with_entities(table.datetime, table.blueprint, table.path)
+
+    sql_query = table.query
+
+    if latest >= 0:
+        sql_query = sql_query.filter(
+            table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
+        )
+
+    sql_query = sql_query.with_entities(table.datetime, table.blueprint, table.path)
     df = md.query_to_dataframe(sql_query)
 
     click.echo("Generating plot...")

--- a/cli/cli_usage.py
+++ b/cli/cli_usage.py
@@ -1,5 +1,6 @@
 import click
 import json
+import datetime
 import pandas as pd
 import numpy as np
 import backend.models as md
@@ -53,17 +54,30 @@ def stats():
 
 
 @usage.command()
+@click.option(
+    "--latest", default=30, type=int, help="Only shows data from latest days."
+)
 @with_appcontext
-def plot_requests_per_blueprint_hist():
+def plot_requests_per_blueprint_hist(latest):
 
     click.echo("Reading database...")
-    df = md.table_to_dataframe(md.Usage, columns=["datetime", "blueprint"])
+
+    table = md.Usage
+    sql_query = table.query.filter(
+        table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
+    ).with_entities(table.datetime, table.blueprint)
+    df = md.query_to_dataframe(sql_query)
 
     click.echo("Generating plot...")
     df.dropna(subset=["datetime", "blueprint"], inplace=True)
 
     df["day"] = df.datetime.dt.floor("d")
-    fig = px.histogram(df, x="day", color="blueprint")
+    df = df.groupby(["day", "blueprint"]).size().to_frame()
+    df.columns = ["count"]
+    df.reset_index(level=0, inplace=True)
+    df.reset_index(level=0, inplace=True)
+
+    fig = px.histogram(df, x="day", y="count", color="blueprint")
 
     fig.update_layout(
         title="Requests per page per day",
@@ -83,11 +97,18 @@ def plot_requests_per_blueprint_hist():
 
 
 @usage.command()
+@click.option(
+    "--latest", default=30, type=int, help="Only shows data from latest days."
+)
 @with_appcontext
-def plot_views_per_blueprint_hist():
+def plot_views_per_blueprint_hist(latest):
 
     click.echo("Reading database...")
-    df = md.table_to_dataframe(md.Usage, columns=["datetime", "blueprint", "path"])
+    table = md.Usage
+    sql_query = table.query.filter(
+        table.datetime >= datetime.datetime.now() - datetime.timedelta(days=latest)
+    ).with_entities(table.datetime, table.blueprint, table.path)
+    df = md.query_to_dataframe(sql_query)
 
     click.echo("Generating plot...")
     df.dropna(subset=["datetime", "blueprint"], inplace=True)
@@ -99,7 +120,12 @@ def plot_views_per_blueprint_hist():
     df = df[index]
 
     df["day"] = df.datetime.dt.floor("d")
-    fig = px.histogram(df, x="day", color="blueprint")
+    df = df.groupby(["day", "blueprint"]).size().to_frame()
+    df.columns = ["count"]
+    df.reset_index(level=0, inplace=True)
+    df.reset_index(level=0, inplace=True)
+
+    fig = px.histogram(df, x="day", y="count", color="blueprint")
 
     fig.update_layout(
         title="Views per page per day",
@@ -213,13 +239,17 @@ def plot_unique_ip_addresses_per_day():
 def plot_platforms_pie():
 
     click.echo("Reading database...")
-    df = md.table_to_dataframe(md.Usage, columns=["ua_platform"])
+    sql_query = md.Usage.query.with_entities(md.Usage.ua_platform)
+    df = md.query_to_dataframe(sql_query)
 
     click.echo("Generating plot...")
 
-    df.dropna(subset=["ua_platform"], inplace=True)
+    df["ua_platform"] = df["ua_platform"].str.lower()
+    df = df.groupby("ua_platform").size().to_frame()
+    df.columns = ["count"]
+    df.reset_index(level=0, inplace=True)
 
-    fig = px.pie(df, names="ua_platform")
+    fig = px.pie(df, values="count", names="ua_platform")
 
     fig.update_traces(textposition="inside", textinfo="percent+label")
 

--- a/cli/cli_usage.py
+++ b/cli/cli_usage.py
@@ -1,5 +1,6 @@
-import json
 import datetime
+import json
+
 import click
 import flask
 import numpy as np


### PR DESCRIPTION
In this PR, I propose a solution to the problem of large size plots that take seconds to generate and load in the browser.

The memory footprint was reduced by a factor of x1000: largest image came down from 180 MB to 180 kB. Use `redis-cli --big-keys` to see biggest keys.

Now, the data is compressed as much as possible in backend, and by default usage data is only shown for the past 30 days.