### PR TITLE
eslint - no-console

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'semi': [
       'error',
       'always'
-    ]
+    ],
+    'no-console': 'error',
   }
 };


### PR DESCRIPTION
Now, an error is triggered if a console.log is left in the code, see: https://eslint.org/docs/rules/no-console