### PR TITLE
fix(js): wrong week number 

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -22,6 +22,20 @@ const uclWeeksNo = {
 
 };
 
+Date.prototype.getWeekNumber = function(){
+  var d = new Date(Date.UTC(this.getFullYear(), this.getMonth(), this.getDate()));
+  var dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+  return Math.ceil((((d - yearStart) / 86400000) + 1)/7);
+};
+
+Date.prototype.addDays = function(days) {
+  var date = new Date(this.valueOf());
+  date.setDate(date.getDate() + days);
+  return date;
+};
+
 
 document.addEventListener('DOMContentLoaded', function() {
   var isTouchDevice = !!('ontouchstart' in window || navigator.maxTouchPoints);
@@ -93,13 +107,11 @@ document.addEventListener('DOMContentLoaded', function() {
           firstDay: 1,
           weekNumbers: true,
           weekNumberContent: function (arg) {
-          // Get week number & year
-          // From: https://stackoverflow.com/a/6117889
-            let d = new Date(Date.UTC(arg.date.getFullYear(), arg.date.getMonth(), arg.date.getDate()));
-            d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay()||7));
-            let yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
-            let weekNo = Math.ceil(( ( (d - yearStart) / 86400000) + 1)/7);
-            let year = d.getUTCFullYear();
+            // Get week number & year
+            // From: https://stackoverflow.com/a/6117889
+            // Since FC set first day to be Sunday in some places, we shift the current day by one to be at least Monday, otherwise we get previous week number.
+            let weekNo = arg.date.addDays(1).getWeekNumber();
+            let year = arg.date.getUTCFullYear();
             let num;
             try {
               num = uclWeeksNo[year][weekNo-1];


### PR DESCRIPTION
This fixes a week number problem that occurs in places where the week starts on Sunday, thus decreasing the expected week number by 1.