### PR TITLE
Docker documentation path independent

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y update
 # Install needed deps for python install
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install openssl-devel \
-                   libffi-devel \ 
+                   libffi-devel \
                    bzip2-devel \
                    sqlite-devel \
                    ncurses-devel \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ```bash
 docker build -f Dockerfile -t ade-scheduler .
-docker run --name ade-scheduler -it -v $HOME/Documents/ADE-Scheduler:/ADE-Scheduler ade-scheduler
+docker run --name ade-scheduler -it -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
 docker start -i ade-scheduler       # To run the app
 docker exec -it ade-scheduler zsh   # To e.g. run `flask shell`
 ```


### PR DESCRIPTION
The current README for docker installation is dependent on the path where the repository is located. This small commit attempts to make explicit the use of the path where the repository is located.