### PR TITLE
Better dev environment (through a Docker) for the OW22

### DIFF
--- a/.flaskenv.default
+++ b/.flaskenv.default
@@ -1,0 +1,30 @@
+# FLASK
+FLASK_APP = "app.py"
+FLASK_ENV = development
+FLASK_RUN_HOST = localhost
+FLASK_RUN_PORT = 5000
+FLASK_SECRET_KEY= ABCDEF
+FLASK_SALT= GHIJKL
+TEMPLATE_AUTO_RELOAD = True
+
+# DEV
+ADE_URL=https://gw.api.uclouvain.be/token
+ADE_DATA = grant_type=client_credentials
+ADE_AUTHORIZATION = Basic some_secret_key
+
+# UCLOUVAIN OAUTH2 API
+UCLOUVAIN_CLIENT_ID = some_secret_id
+UCLOUVAIN_CLIENT_SECRET = some_secret_secret
+
+# DB
+ADE_DB_PATH = sqlite:///adescheduler.db
+
+# LOGGING
+MAIL_SERVER = smtp.gmail.com
+MAIL_USERNAME = no-email@gmail.com
+MAIL_PASSWORD = some-password
+MAIL_ADMIN = no-email@gmail.com
+MAIL_DISABLE = true
+
+# USE FAKE API
+ADE_FAKE_API = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v8.12.0'  # Use the sha / tag you want to point at
+    rev: 'v8.17.0'  # Use the sha / tag you want to point at
     hooks:
     -   id: eslint
         additional_dependencies:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y update
 # Install needed deps for python install
 RUN yum -y groupinstall "Development Tools"
 RUN yum -y install openssl-devel \
-                   libffi-devel \ 
+                   libffi-devel \
                    bzip2-devel \
                    sqlite-devel \
                    ncurses-devel \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,13 +35,9 @@ RUN yum -y --enablerepo=remi install redis
 RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
 RUN yum -y install nodejs
 
-# Install ZSH & Oh-My-Zsh (cuz it's WAY better...)
-RUN yum -y install zsh
-
 # Add dev user
 RUN useradd -ms /bin/bash dev
 USER dev
-RUN sh -c "$(wget https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)"
 
 # Entrypoint
 COPY entrypoint.sh /run/entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM centos:centos7.9.2009
+
+
+RUN yum -y update
+
+# Install needed deps for python install
+RUN yum -y groupinstall "Development Tools"
+RUN yum -y install openssl-devel \
+                   libffi-devel \ 
+                   bzip2-devel \
+                   sqlite-devel \
+                   ncurses-devel \
+                   libreadline5-dev \
+                   wget
+
+# Install Python 3.10
+RUN wget https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz
+RUN tar xvf Python-3.9.10.tgz
+WORKDIR "/Python-3.9.10"
+RUN ./configure --enable-optimizations \
+                --enable-loadable-sqlite-extensions
+RUN make altinstall -j
+RUN python3.9 -m pip install gnureadline
+WORKDIR "/"
+
+# Install Redis
+RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+RUN yum -y --enablerepo=remi install redis
+
+# Install PostgreSQL
+# RUN yum -y install postgresql-server postgresql-contrib
+# TODO: make postgres work to get the same env as the prod server ?
+
+# Install Node.js
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
+RUN yum -y install nodejs
+
+# Install ZSH & Oh-My-Zsh (cuz it's WAY better...)
+RUN yum -y install zsh
+
+# Add dev user
+RUN useradd -ms /bin/bash dev
+USER dev
+RUN sh -c "$(wget https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)"
+
+# Entrypoint
+COPY entrypoint.sh /run/entrypoint.sh
+ENTRYPOINT ["/run/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,5 +2,5 @@
 docker build -f Dockerfile -t ade-scheduler .
 docker run --name ade-scheduler -it -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
 docker start -i ade-scheduler       # To run the app
-docker exec -it ade-scheduler zsh   # To e.g. run `flask shell`
+docker exec -it ade-scheduler bash  # To e.g. run `flask shell`
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,6 @@
+```bash
+docker build -f Dockerfile -t ade-scheduler .
+docker run --name ade-scheduler -it -v $HOME/Documents/ADE-Scheduler:/ADE-Scheduler ade-scheduler
+docker start -i ade-scheduler       # To run the app
+docker exec -it ade-scheduler zsh   # To e.g. run `flask shell`
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ```bash
 docker build -f Dockerfile -t ade-scheduler .
-docker run --name ade-scheduler -it -v $HOME/Documents/ADE-Scheduler:/ADE-Scheduler ade-scheduler
+docker run --name ade-scheduler -it -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
 docker start -i ade-scheduler       # To run the app
 docker exec -it ade-scheduler zsh   # To e.g. run `flask shell`
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ```bash
 docker build -f Dockerfile -t ade-scheduler .
-docker run --name ade-scheduler -it -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
+docker run --name ade-scheduler -it -p 5000:5000 -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
 docker start -i ade-scheduler       # To run the app
 docker exec -it ade-scheduler bash  # To e.g. run `flask shell`
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Go to folder
+cd /ADE-Scheduler
+
+# Update & install Node deps (& run Webpack)
+npm install
+echo "Running Webpack..."
+npx webpack --progress --watch --no-stats &
+
+# Update & install Python deps
+if [ -d "venv" ]; then
+    echo "Installing virtualenv..."
+    python3.9 -m venv venv
+fi
+source venv/bin/activate
+pip install -r dev-requirements.txt
+
+#  Run Redis
+redis-server &
+
+# Run postgresql
+# this is complicated, use sqlite for dev instead lol
+
+# Run Flask !
+echo "Running Flask..."
+flask run

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,7 @@ echo "Running Webpack..."
 npx webpack --progress --watch --no-stats &
 
 # Update & install Python deps
-if [ -d "venv" ]; then
+if [ ! -d "venv" ]; then
     echo "Installing virtualenv..."
     python3.9 -m venv venv
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,12 @@ fi
 source venv/bin/activate
 pip install -r dev-requirements.txt
 
+# Create .flaskenv from default
+if [ ! -f ".flaskenv" ]; then
+    echo "Creating .flaskenv..."
+    cp .flaskenv.default .flaskenv
+fi
+
 #  Run Redis
 redis-server &
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,7 @@ redis-server &
 
 # Run postgresql
 # this is complicated, use sqlite for dev instead lol
+flask sql init
 
 # Run Flask !
 echo "Running Flask..."

--- a/docs/source/backend/cookies.rst
+++ b/docs/source/backend/cookies.rst
@@ -1,0 +1,7 @@
+cookies module
+==============
+
+.. automodule:: cookies
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/backend/mixins.rst
+++ b/docs/source/backend/mixins.rst
@@ -1,0 +1,7 @@
+mixins module
+=============
+
+.. automodule:: mixins
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/backend/modules.rst
+++ b/docs/source/backend/modules.rst
@@ -6,11 +6,16 @@ backend
 
    ade_api
    classrooms
+   cookies
    courses
    events
    manager
+   mixins
    models
    professors
    resources
    schedules
+   security
    servers
+   track_usage
+   uclouvain_apis

--- a/docs/source/backend/security.rst
+++ b/docs/source/backend/security.rst
@@ -1,0 +1,7 @@
+security module
+===============
+
+.. automodule:: security
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/backend/track_usage.rst
+++ b/docs/source/backend/track_usage.rst
@@ -1,0 +1,7 @@
+track\_usage module
+===================
+
+.. automodule:: track_usage
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/backend/uclouvain_apis.rst
+++ b/docs/source/backend/uclouvain_apis.rst
@@ -1,0 +1,7 @@
+uclouvain\_apis module
+======================
+
+.. automodule:: uclouvain_apis
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/tutorials/ade-scheduler.rst
+++ b/docs/source/tutorials/ade-scheduler.rst
@@ -39,7 +39,7 @@ I. Clone the repository
 -----------------------
 
 If you are not one of the official maintainers of this project, you should first fork
-this repository: https://github.com/SnaKyEyeS/ADE-Scheduler/fork
+this repository: https://github.com/ADE-Scheduler/ADE-Scheduler/fork
 
 Then, clone the forked repository somewhere on your machine. We will always refer to
 the location of the project directory as :code:`<repo>`.

--- a/docs/source/tutorials/docker.rst
+++ b/docs/source/tutorials/docker.rst
@@ -1,0 +1,58 @@
+
+======================
+Docker setup tutorials
+======================
+
+.. docker info begin
+
+.. note::
+
+    This section will describe how to install and run ADE Scheduler under Docker on your system.
+
+.. docker info end
+
+.. contents:: Table of content
+
+
+Docker setup
+============
+
+.. note::
+    Even though it was not tested, this setup should work on any platform: Linux, Mac OS X, Windows.
+
+.. docker setup begin
+
+I. Install Docker
+-----------------
+
+First, you must have Docker installed on your system. We recommend to install it from the official website: https://docs.docker.com/desktop/#download-and-install
+
+II. Pull Docker image
+---------------------
+
+Pull the Docker image:
+
+.. code-block:: console
+
+    $ docker pull gilponcelet/ade-scheduler
+
+
+III. Build and run the ADE Scheduler server
+-------------------------------------------
+
+Run the following in :code:`<repo>`:
+
+.. code-block:: console
+
+    $ docker build -f Dockerfile -t ade-scheduler .
+    $ docker run --name ade-scheduler -it -p 5000:5000 -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
+    $ docker start -i ade-scheduler       # To run the app
+    $ docker exec -it ade-scheduler bash  # To e.g. run `flask shell`
+
+.. warning::
+
+    This tutorial is still under development! Any problem you might encounter is important for us, so please contact use whenever you need help :-)
+
+.. docker setup end
+
+

--- a/docs/source/tutorials/docker.rst
+++ b/docs/source/tutorials/docker.rst
@@ -54,5 +54,3 @@ Run the following in :code:`<repo>`:
     This tutorial is still under development! Any problem you might encounter is important for us, so please contact use whenever you need help :-)
 
 .. docker setup end
-
-

--- a/docs/source/tutorials/setup.rst
+++ b/docs/source/tutorials/setup.rst
@@ -19,6 +19,21 @@ with more details on how to use particular tools.
     It is important to follow this setup guide in the correct order of sections!
 
 
+(*New*) Docker setup
+====================
+
+A new setup alternative is the Docker setup. This setup is a lot more simple as it will install most of the requirements for you.
+
+
+.. include:: docker.rst
+    :start-after: docker info begin
+    :end-before: docker info end
+
+
+.. include:: docker.rst
+    :start-after: docker setup begin
+    :end-before: docker setup end
+
 1. Redis server
 ===============
 

--- a/docs/source/views/admin.rst
+++ b/docs/source/views/admin.rst
@@ -1,0 +1,7 @@
+admin module
+============
+
+.. automodule:: admin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/views/contribute.rst
+++ b/docs/source/views/contribute.rst
@@ -1,0 +1,7 @@
+contribute module
+=================
+
+.. automodule:: contribute
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/views/modules.rst
+++ b/docs/source/views/modules.rst
@@ -5,10 +5,13 @@ views
    :maxdepth: 4
 
    account
+   admin
    api
    calendar
    classroom
    contact
+   contribute
    help
+   security
    utils
    whatisnew

--- a/docs/source/views/security.rst
+++ b/docs/source/views/security.rst
@@ -1,0 +1,7 @@
+security module
+===============
+
+.. automodule:: security
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ADE-Scheduler",
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {

--- a/prod-requirements.txt
+++ b/prod-requirements.txt
@@ -13,6 +13,7 @@ flask_sqlalchemy==2.5.1
 geopy==2.2.0
 ics==0.7
 jsmin==3.0.1
+jinja2==3.0.2
 lxml==4.6.5
 numpy==1.22.1
 pandas==1.4.0

--- a/prod-requirements.txt
+++ b/prod-requirements.txt
@@ -13,7 +13,6 @@ flask_sqlalchemy==2.5.1
 geopy==2.2.0
 ics==0.7
 jsmin==3.0.1
-jinja2==3.0.2
 lxml==4.6.5
 numpy==1.22.1
 pandas==1.4.0
@@ -32,4 +31,4 @@ bcrypt==3.2.0
 bleach==4.1.0
 authlib==0.15.5
 cryptography==3.4.7
-jinja2==3.0
+jinja2==3.0.2

--- a/views/security.py
+++ b/views/security.py
@@ -17,7 +17,7 @@ security = Blueprint("security", __name__, static_folder="../static")
 @security.route("/login")
 def login():
     # The UCLouvain login API does not work in dev
-    # (unless you run the derver under ade-scheduler.info.ucl.ac.be on port 443
+    # (unless you run the server under ade-scheduler.info.ucl.ac.be on port 443
     #  which can be achieved by editing /etc/hosts should you need to dev stuff
     #  related to the login.)
     # WARNING: this won't work the day where we want to add features requiring


### PR DESCRIPTION
To prepare for the OpenWeek, we improve the dev environment by:

  - adding a docker to ease the installation/setup (`docker pull gilponcelet/ade-scheduler`)
    - [x] make a default `.flaskenv`
    - [x] get a proxy API working on a RPi (@louisna)
    - [x] update the doc to document the docker installation procedure
  - default "dev" user (using the UCLouvain Oauth in dev is tricky, as it requires access to the UCLouvain API & setting up the dev env on the https://ade-scheduler.info.ucl.ac.be URL directly)