### PR TITLE
[Docker] publish port 5000 in documentation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 ```bash
 docker build -f Dockerfile -t ade-scheduler .
-docker run --name ade-scheduler -it -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
+docker run --name ade-scheduler -it -p 5000:5000 -v <Path to ADE-Scheduler folder>:/ADE-Scheduler ade-scheduler
 docker start -i ade-scheduler       # To run the app
 docker exec -it ade-scheduler bash  # To e.g. run `flask shell`
 ```


### PR DESCRIPTION
Add port publication information in the README to make the server reachable from outside the docker.