### PR TITLE
fix(bug): enable lazy course update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/pre-commit/mirrors-eslint
+  - repo: https://github.com/pre-commit/mirrors-eslint
     rev: 'v8.23.0'  # Use the sha / tag you want to point at
     hooks:
       - id: eslint
@@ -14,7 +14,7 @@ repos:
           - eslint-plugin-vue@7.17.0
         args: [--fix]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: '5.10.1'
     hooks:
       - id: isort
         args: ['--profile', 'black', '--filter-files']

--- a/.redis-config-ttl.cfg
+++ b/.redis-config-ttl.cfg
@@ -9,7 +9,7 @@
 [production]
 classrooms: hours=25
 course_resources: days=25
-courses: hours=3
+courses: minutes=30
 events_in_classroom: hours=3
 project_ids: hours=25
 resource_ids: hours=25

--- a/.redis-config-ttl.cfg
+++ b/.redis-config-ttl.cfg
@@ -20,7 +20,7 @@ user_session: days=100
 [development]
 classrooms: days=2
 course_resources: days=2
-courses: seconds=30
+courses: days=1
 events_in_classroom: days=1
 project_ids: days=1
 resource_ids: days=2

--- a/.redis-config-ttl.cfg
+++ b/.redis-config-ttl.cfg
@@ -9,7 +9,7 @@
 [production]
 classrooms: hours=25
 course_resources: days=25
-courses: minutes=30
+courses: minutes=5
 events_in_classroom: hours=3
 project_ids: hours=25
 resource_ids: hours=25
@@ -20,7 +20,7 @@ user_session: days=100
 [development]
 classrooms: days=2
 course_resources: days=2
-courses: days=1
+courses: seconds=30
 events_in_classroom: days=1
 project_ids: days=1
 resource_ids: days=2

--- a/.redis-config-ttl.cfg
+++ b/.redis-config-ttl.cfg
@@ -9,7 +9,9 @@
 [production]
 classrooms: hours=25
 course_resources: days=25
-courses: minutes=5
+courses: hours=25
+courses_notify: hours=3
+courses_renotify: minutes=5
 events_in_classroom: hours=3
 project_ids: hours=25
 resource_ids: hours=25
@@ -21,6 +23,8 @@ user_session: days=100
 classrooms: days=2
 course_resources: days=2
 courses: days=1
+courses_notify: hours=3
+courses_renotify: minutes=5
 events_in_classroom: days=1
 project_ids: days=1
 resource_ids: days=2

--- a/backend/manager.py
+++ b/backend/manager.py
@@ -85,9 +85,11 @@ class Manager:
         if codes_not_found:
             for code_not_found in codes_not_found:
                 if code_not_found.startswith("EXT:"):
-                    extCal = md.ExternalCalendar.query.filter_by(approved=True).filter(
-                        md.ExternalCalendar.code == code_not_found
-                    ).first()
+                    extCal = (
+                        md.ExternalCalendar.query.filter_by(approved=True)
+                        .filter(md.ExternalCalendar.code == code_not_found)
+                        .first()
+                    )
                     if extCal is None:  # In case the owner of extCal deleted it
                         codes.remove(code_not_found)
                         continue
@@ -241,9 +243,9 @@ class Manager:
         courses_matching.extend(
             map(
                 lambda ec: ec.code,
-                md.ExternalCalendar.query.filter_by(approved=True).filter(
-                    md.ExternalCalendar.code.contains(pattern)
-                ).all(),
+                md.ExternalCalendar.query.filter_by(approved=True)
+                .filter(md.ExternalCalendar.code.contains(pattern))
+                .all(),
             )
         )
         return courses_matching
@@ -344,9 +346,9 @@ class Manager:
         """
         if code.startswith("EXT:"):
             return (
-                md.ExternalCalendar.query.filter_by(approved=True).filter(
-                    md.ExternalCalendar.code == code
-                ).first()
+                md.ExternalCalendar.query.filter_by(approved=True)
+                .filter(md.ExternalCalendar.code == code)
+                .first()
                 is not None
             )
         if project_id is None:

--- a/backend/manager.py
+++ b/backend/manager.py
@@ -129,6 +129,7 @@ class Manager:
                 self.server.set_value(
                     prefix + code_not_found,
                     course_not_found,
+                    expire_in=self.ttl["classrooms"],
                     notify_expire_in=self.ttl["courses"],
                 )
                 courses[code_not_found] = course_not_found
@@ -149,6 +150,7 @@ class Manager:
                 self.server.set_value(
                     prefix + code_expired,
                     course_expired,
+                    expire_in=self.ttl["classrooms"],
                     notify_expire_in=self.ttl["courses"],
                 )
             except lxml.etree.XMLSyntaxError as e:

--- a/backend/manager.py
+++ b/backend/manager.py
@@ -129,8 +129,8 @@ class Manager:
                 self.server.set_value(
                     prefix + code_not_found,
                     course_not_found,
-                    expire_in=self.ttl["classrooms"],
-                    notify_expire_in=self.ttl["courses"],
+                    expire_in=self.ttl["courses"],
+                    notify_expire_in=self.ttl["courses_notify"],
                 )
                 courses[code_not_found] = course_not_found
 
@@ -150,14 +150,15 @@ class Manager:
                 self.server.set_value(
                     prefix + code_expired,
                     course_expired,
-                    expire_in=self.ttl["classrooms"],
-                    notify_expire_in=self.ttl["courses"],
+                    expire_in=self.ttl["courses"],
+                    notify_expire_in=self.ttl["courses_notify"],
                 )
             except lxml.etree.XMLSyntaxError as e:
                 self.server.set_value(
                     prefix + code_expired,
                     courses[code_expired],  # this already exists
-                    notify_expire_in=self.ttl["courses"],
+                    expire_in=self.ttl["courses"],
+                    notify_expire_in=self.ttl["courses_renotify"],
                 )
 
         ret = list()

--- a/backend/manager.py
+++ b/backend/manager.py
@@ -1,5 +1,6 @@
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
+import lxml
 import pandas as pd
 import requests
 from flask_babel import gettext
@@ -77,45 +78,85 @@ class Manager:
 
         # Fetch from the server
         prefix = f"[project_id={project_id}]"
+
+        courses_expired = self.server.get_multiple_values_expired(
+            *codes,
+            prefix=prefix,
+        )
         courses, codes_not_found = self.server.get_multiple_values(
             *codes, prefix=prefix
         )
 
+        def _fetch_code(code_not_found):
+            course_not_found = None
+            if code_not_found.startswith("EXT:"):
+                extCal = (
+                    md.ExternalCalendar.query.filter_by(approved=True)
+                    .filter(md.ExternalCalendar.code == code_not_found)
+                    .first()
+                )
+                if extCal is None:  # In case the owner of extCal deleted it
+                    return None
+                url = extCal.url
+                events = Calendar(requests.get(url).text).events
+                events = [
+                    evt.EventEXTERN.from_event(event, code_not_found[4:])
+                    for event in events
+                ]
+                course_not_found = crs.Course(code_not_found[4:], extCal.name)
+                for event in events:
+                    course_not_found.add_activity([event])
+
+            else:
+                resource_ids = self.get_resource_ids(
+                    code_not_found, project_id=project_id
+                )
+                course_not_found = ade.response_to_courses(
+                    self.client.get_activities(resource_ids, project_id)
+                )
+
+            return course_not_found
+
         # Fetch from the api the missing courses
         if codes_not_found:
             for code_not_found in codes_not_found:
-                if code_not_found.startswith("EXT:"):
-                    extCal = (
-                        md.ExternalCalendar.query.filter_by(approved=True)
-                        .filter(md.ExternalCalendar.code == code_not_found)
-                        .first()
-                    )
-                    if extCal is None:  # In case the owner of extCal deleted it
-                        codes.remove(code_not_found)
-                        continue
-                    url = extCal.url
-                    events = Calendar(requests.get(url).text).events
-                    events = [
-                        evt.EventEXTERN.from_event(event, code_not_found[4:])
-                        for event in events
-                    ]
-                    course_not_found = crs.Course(code_not_found[4:], extCal.name)
-                    for event in events:
-                        course_not_found.add_activity([event])
+                course_not_found = _fetch_code(code_not_found)
 
-                else:
-                    resource_ids = self.get_resource_ids(
-                        code_not_found, project_id=project_id
-                    )
-                    course_not_found = ade.response_to_courses(
-                        self.client.get_activities(resource_ids, project_id)
-                    )
+                if course_not_found is None:
+                    codes.remove(code_not_found)
+                    continue
+
                 self.server.set_value(
                     prefix + code_not_found,
                     course_not_found,
-                    expire_in=self.ttl["courses"],
+                    notify_expire_in=self.ttl["courses"],
                 )
                 courses[code_not_found] = course_not_found
+
+        # Fetch from the api the courses that have expired
+        # those can have errors, we will fetch them later
+        for code_expired in [
+            key for key, expired in courses_expired.items() if expired is True
+        ]:
+            try:
+                course_expired = _fetch_code(code_expired)
+
+                if course_expired is None:
+                    codes.remove(code_expired)
+                    continue
+
+                courses[code_expired] = course_expired
+                self.server.set_value(
+                    prefix + code_expired,
+                    course_expired,
+                    notify_expire_in=self.ttl["courses"],
+                )
+            except lxml.etree.XMLSyntaxError as e:
+                self.server.set_value(
+                    prefix + code_expired,
+                    courses[code_expired],  # this already exists
+                    notify_expire_in=self.ttl["courses"],
+                )
 
         ret = list()
 

--- a/backend/servers.py
+++ b/backend/servers.py
@@ -20,6 +20,8 @@ REQUIRED_CONFIG_KEYS = [
     "classrooms",
     "course_resources",
     "courses",
+    "courses_notify",
+    "courses_renotify",
     "events_in_classroom",
     "project_ids",
     "resource_ids",
@@ -147,7 +149,7 @@ class Server(Redis):
 
         if notify_expire_in:
             key = f"{key}_is_alive"
-            self.setex(key, timedelta(**notify_expire_in), dumps(True))
+            self.setex(key, timedelta(**notify_expire_in), "")
 
     def contains(self, *keys: str) -> int:
         """

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -119,8 +119,8 @@ document.addEventListener('DOMContentLoaded', () => {
           locale: document.getElementById('current-locale').innerText.trim(),
           timeZone: 'Europe/Brussels', // Show schedule in the same TZ where classes are given
           height: 'auto',
-          // slotMinTime: '08:00:00',
-          // slotMaxTime: '21:00:00',
+          slotMinTime: '08:00:00',
+          slotMaxTime: '21:00:00',
           navLinks: true, // can click day/week names to navigate views
           editable: false,
           droppable: false,
@@ -369,6 +369,8 @@ document.addEventListener('DOMContentLoaded', () => {
             this.currentSchedule = resp.data.current_schedule;
             this.setUnsavedStatus(resp.data.unsaved);
             this.autoSave = resp.data.autosave;
+            this.calendarOptions.slotMinTime = resp.data.min_time_slot;
+            this.calendarOptions.slotMaxTime = resp.data.max_time_slot;
           })
           .catch((err) => {
             store.error(err.response.data);
@@ -393,6 +395,8 @@ document.addEventListener('DOMContentLoaded', () => {
               this.calendarOptions.events = resp.data.events;
               this.currentSchedule = resp.data.current_schedule;
               this.setUnsavedStatus(resp.data.unsaved);
+              this.calendarOptions.slotMinTime = resp.data.min_time_slot;
+              this.calendarOptions.slotMaxTime = resp.data.max_time_slot;
             })
             .catch((err) => {
               store.error(err.response.data);
@@ -587,6 +591,8 @@ document.addEventListener('DOMContentLoaded', () => {
               this.code = '';
               this.selected_schedule = 0;
               this.setUnsavedStatus(resp.data.unsaved);
+              this.calendarOptions.slotMinTime = resp.data.min_time_slot;
+              this.calendarOptions.slotMaxTime = resp.data.max_time_slot;
             })
             .catch((err) => {
               if (err.response.status === 404) {
@@ -613,6 +619,8 @@ document.addEventListener('DOMContentLoaded', () => {
             this.calendarOptions.events = resp.data.events;
             this.selected_schedule = 0;
             this.setUnsavedStatus(resp.data.unsaved);
+            this.calendarOptions.slotMinTime = resp.data.min_time_slot;
+            this.calendarOptions.slotMaxTime = resp.data.max_time_slot;
           })
           .catch((err) => {
             store.error(err.response.data);

--- a/views/account.py
+++ b/views/account.py
@@ -258,7 +258,7 @@ def add_external_calendar():
             course["code"].upper(),
             course["name"],
             url,
-            course["description"],
+            course.get("description", None),
             current_user,
             False,
         )  # False: waiting to be approved

--- a/views/calendar.py
+++ b/views/calendar.py
@@ -99,6 +99,7 @@ def clear():
 @calendar.route("/data", methods=["GET"])
 def get_data():
     mng = app.config["MANAGER"]
+    min_time_slot, max_time_slot = session["current_schedule"].get_min_max_time_slots()
     return (
         jsonify(
             {
@@ -121,6 +122,8 @@ def get_data():
                     )
                 ),
                 "autosave": getattr(current_user, "autosave", False),
+                "min_time_slot": min_time_slot,
+                "max_time_slot": max_time_slot,
             }
         ),
         200,
@@ -135,6 +138,9 @@ def load_schedule(id):
     if schedule:
         session["current_schedule"] = schedule.data
         session["current_schedule_modified"] = False
+        min_time_slot, max_time_slot = session[
+            "current_schedule"
+        ].get_min_max_time_slots()
         return (
             jsonify(
                 {
@@ -154,6 +160,8 @@ def load_schedule(id):
                             current_user.get_schedules(),
                         )
                     ),
+                    "min_time_slot": min_time_slot,
+                    "max_time_slot": max_time_slot,
                 }
             ),
             200,
@@ -178,6 +186,8 @@ def add_code(code):
         return gettext("The code you added does not exist in our database."), 404
 
     codes = session["current_schedule"].add_course(code)
+
+    min_time_slot, max_time_slot = session["current_schedule"].get_min_max_time_slots()
     if codes:
         session["current_schedule_modified"] = True
     return (
@@ -185,6 +195,8 @@ def add_code(code):
             {
                 "codes": codes,
                 "events": session["current_schedule"].get_events(json=True),
+                "min_time_slot": min_time_slot,
+                "max_time_slot": max_time_slot,
             }
         ),
         200,
@@ -195,7 +207,18 @@ def add_code(code):
 def remove_code(code):
     session["current_schedule"].remove_course(code)
     session["current_schedule_modified"] = True
-    return (jsonify({"events": session["current_schedule"].get_events(json=True)}), 200)
+
+    min_time_slot, max_time_slot = session["current_schedule"].get_min_max_time_slots()
+    return (
+        jsonify(
+            {
+                "events": session["current_schedule"].get_events(json=True),
+                "min_time_slot": min_time_slot,
+                "max_time_slot": max_time_slot,
+            }
+        ),
+        200,
+    )
 
 
 @calendar.route("/<path:code>/info", methods=["GET"])


### PR DESCRIPTION
This enables to update courses only if the request succeeds. If the request fails and the course was already present, then we use previous version.

This should help lowering the number of error messages we have. With this, I propose to reduce the interval time to 30 minutes, since any error will add another 30 minutes.

This feature can also be activated for other requests, but will required quite some work and I am not sure it's that important for the moment :'-)