### PR TITLE
feat: add errors from API (lxml syntax error) to emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 - [Eertmans Jérome](https://www.linkedin.com/in/j%C3%A9rome-eertmans-130ab1130/) (active maintainer)
 - [Navarre Louis](https://www.linkedin.com/in/louis-navarre-36b78b143/)
-- [Poncelet Gilles](https://www.linkedin.com/in/gilles-poncelet-020442195/) (active maintainer)
+- [Poncelet Gilles](https://www.linkedin.com/in/gilles-poncelet-020442195/)
 
 We are three former students from the Ecole Polytechnique de Louvain (EPL) and were starting our first master year at the start of the project.
 

--- a/app.py
+++ b/app.py
@@ -401,6 +401,26 @@ def migrate(token):
     return redirect(url_for("calendar.index"))
 
 
+def format_error_into_message(e: Exception, request, subject="ADE Scheduler Failure: {}") -> Message:
+    """
+    Formats the error into a (Email) message.
+    """
+    error = getattr(e, "original_exception", e)
+    error_request = f"{request.path} [{request.method}]"
+    error_module = error.__class__.__module__
+    if error_module is None:
+        error_name = error.__class__.__name__
+    else:
+        error_name = f"{error_module}.{error.__class__.__name__}"
+    error_details = str(traceback.format_exc())
+    msg = Message(
+        subject=subject.format(error_name),
+        body=f"Exception on {error_request}: {str(error)}\n\n{error_details}",
+        recipients=app.config["ADMINS"],
+    )
+    return msg
+
+
 # Error handlers
 @app.errorhandler(HTTPError)
 @app.errorhandler(ConnectionError)
@@ -423,6 +443,10 @@ def handle_empty_ade_responses(e):
     However, it does seem to resolve itself by trying again...
     In the meanwhile, flash an error message asking the user to try again.
     """
+    if not app.debug and app.config["MAIL_SEND_ERRORS"]:
+        msg = format_error_into_message(e, request, subject="ADE API Failure: {}")
+        app.config["MAIL_MANAGER"].send(msg)
+
     err_text = gettext(
         "Hum... it looks like there's been a bug with the ADE API. Please try again and if the problem persists, do not hesitate to contact us !"
     )
@@ -436,19 +460,7 @@ def handle_empty_ade_responses(e):
 @app.errorhandler(InternalServerError)
 def handle_exception(e):
     if not app.debug and app.config["MAIL_SEND_ERRORS"]:
-        error = e.original_exception
-        error_request = f"{request.path} [{request.method}]"
-        error_module = error.__class__.__module__
-        if error_module is None:
-            error_name = error.__class__.__name__
-        else:
-            error_name = f"{error_module}.{error.__class__.__name__}"
-        error_details = str(traceback.format_exc())
-        msg = Message(
-            subject=f"ADE Scheduler Failure: {error_name}",
-            body=f"Exception on {error_request}: {str(error)}\n\n{error_details}",
-            recipients=app.config["ADMINS"],
-        )
+        msg = format_error_into_message(e, request)
         app.config["MAIL_MANAGER"].send(msg)
 
     if request.accept_mimetypes.best == "application/json":


### PR DESCRIPTION
We know send emails for API related errors, i.e., error from lxml parsing api responses.